### PR TITLE
Improve user ergonomics, performance and deny a timing attack

### DIFF
--- a/benches/jwt.rs
+++ b/benches/jwt.rs
@@ -13,14 +13,12 @@ struct Claims {
 
 #[bench]
 fn bench_encode(b: &mut test::Bencher) {
-    b.iter(|| encode::<Claims>(
-        Claims {
-            sub: "b@b.com".to_owned(),
-            company: "ACME".to_owned()
-        },
-        "secret".to_owned(),
-        Algorithm::HS256
-    ));
+    let claim = Claims {
+        sub: "b@b.com".to_owned(),
+        company: "ACME".to_owned()
+    };
+
+    b.iter(|| encode(&claim, "secret", Algorithm::HS256));
 }
 
 #[bench]

--- a/benches/jwt.rs
+++ b/benches/jwt.rs
@@ -23,10 +23,6 @@ fn bench_encode(b: &mut test::Bencher) {
 
 #[bench]
 fn bench_decode(b: &mut test::Bencher) {
-    let token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWV9.TJVA95OrM7E2cBab30RMHrHDcEfxjoYZgeFONFh7HgQ".to_owned();
-    b.iter(|| decode::<Claims>(
-        token.clone(),
-        "secret".to_owned(),
-        Algorithm::HS256
-    ));
+    let token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWV9.TJVA95OrM7E2cBab30RMHrHDcEfxjoYZgeFONFh7HgQ";
+    b.iter(|| decode::<Claims>(token, "secret", Algorithm::HS256));
 }

--- a/examples/claims.rs
+++ b/examples/claims.rs
@@ -16,7 +16,7 @@ fn main() {
         company: "ACME".to_owned()
     };
     let key = "secret";
-    let token = match encode::<Claims>(my_claims, key.to_owned(), Algorithm::HS256) {
+    let token = match encode(&my_claims, key, Algorithm::HS256) {
         Ok(t) => t,
         Err(_) => panic!() // in practice you would return the error
     };

--- a/examples/claims.rs
+++ b/examples/claims.rs
@@ -21,7 +21,7 @@ fn main() {
         Err(_) => panic!() // in practice you would return the error
     };
 
-    let claims = match decode::<Claims>(token.to_owned(), key.to_owned(), Algorithm::HS256) {
+    let claims = match decode::<Claims>(&token, key, Algorithm::HS256) {
         Ok(c) => c,
         Err(err) => match err {
             Error::InvalidToken => panic!(), // Example on how to handle a specific error

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -159,7 +159,7 @@ mod tests {
 
     #[test]
     fn sign_hs256() {
-        let result = sign("hello world", "secret".as_bytes(), Algorithm::HS256);
+        let result = sign("hello world", b"secret", Algorithm::HS256);
         let expected = "c0zGLzKEFWj0VxWuufTXiRMk5tlI5MbGDAYhzaxIYjo";
         assert_eq!(result, expected);
     }
@@ -167,8 +167,8 @@ mod tests {
     #[test]
     fn verify_hs256() {
         let sig = "c0zGLzKEFWj0VxWuufTXiRMk5tlI5MbGDAYhzaxIYjo";
-        let result = verify(sig.into(), "hello world", "secret".as_bytes(), Algorithm::HS256);
-        assert!(result == true);
+        let valid = verify(sig, "hello world", b"secret", Algorithm::HS256);
+        assert!(valid);
     }
 
     #[test]
@@ -183,16 +183,18 @@ mod tests {
     }
 
     #[test]
+    #[should_panic(expected = "InvalidToken")]
     fn decode_token_missing_parts() {
         let token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9";
         let claims = decode::<Claims>(token.to_owned(), "secret".to_owned(), Algorithm::HS256);
-        assert_eq!(claims.is_ok(), false);
+        claims.unwrap();
     }
 
     #[test]
+    #[should_panic(expected = "InvalidSignature")]
     fn decode_token_invalid_signature() {
         let token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJiQGIuY29tIiwiY29tcGFueSI6IkFDTUUifQ.wrong";
         let claims = decode::<Claims>(token.to_owned(), "secret".to_owned(), Algorithm::HS256);
-        assert_eq!(claims.is_ok(), false);
+        claims.unwrap();
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,7 @@ use crypto::sha2::{Sha256, Sha384, Sha512};
 use crypto::hmac::Hmac;
 use crypto::mac::Mac;
 use crypto::digest::Digest;
+use crypto::util::fixed_time_eq;
 
 pub mod errors;
 use errors::Error;
@@ -81,7 +82,7 @@ fn sign(data: &str, secret: &[u8], algorithm: Algorithm) -> String {
 
 /// Compares the signature given with a re-computed signature
 fn verify(signature: &str, data: &str, secret: &[u8], algorithm: Algorithm) -> bool {
-    signature == sign(data, secret, algorithm)
+    fixed_time_eq(signature.as_ref(), sign(data, secret, algorithm).as_ref())
 }
 
 /// Encode the claims passed and sign the payload using the algorithm and the secret

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,12 +85,12 @@ fn verify(signature: &str, data: &str, secret: &[u8], algorithm: Algorithm) -> b
 }
 
 /// Encode the claims passed and sign the payload using the algorithm and the secret
-pub fn encode<T: Part>(claims: T, secret: String, algorithm: Algorithm) -> Result<String, Error> {
+pub fn encode<T: Part, B: AsRef<[u8]>>(claims: &T, secret: B, algorithm: Algorithm) -> Result<String, Error> {
     let encoded_header = try!(Header::new(algorithm).to_base64());
     let encoded_claims = try!(claims.to_base64());
     // seems to be a tiny bit faster than format!("{}.{}", x, y)
     let payload = [encoded_header, encoded_claims].join(".");
-    let signature = sign(&*payload, secret.as_bytes(), algorithm);
+    let signature = sign(&*payload, secret.as_ref(), algorithm);
 
     Ok([payload, signature].join("."))
 }
@@ -177,7 +177,7 @@ mod tests {
             sub: "b@b.com".to_owned(),
             company: "ACME".to_owned()
         };
-        let token = encode::<Claims>(my_claims.clone(), "secret".to_owned(), Algorithm::HS256).unwrap();
+        let token = encode(&my_claims, "secret", Algorithm::HS256).unwrap();
         let claims = decode::<Claims>(token.to_owned(), "secret".to_owned(), Algorithm::HS256).unwrap();
         assert_eq!(my_claims, claims);
     }


### PR DESCRIPTION
(sorry for the bundled commits, I can separate them into separate PRs if you need)

This looks pretty useful so I wanted to help improve the ergonomics a bit (and then got a bit sidetracked in making it faster). Most of the ownership was not required (so `to_owned` is generally unnecessary), as the majority of work cannot be done in-place (at least not with current libraries).

This commit fixes a potential timing attack on hmac verification: 486c4a87f9603250167e40d70da2845e04a07500

Performance change:
```bash
# before
test bench_decode ... bench:      11,501 ns/iter (+/- 885)
test bench_encode ... bench:       5,036 ns/iter (+/- 511)

# after
test bench_decode ... bench:       3,460 ns/iter (+/- 718)
test bench_encode ... bench:       3,964 ns/iter (+/- 516)
```